### PR TITLE
feat: windows support

### DIFF
--- a/src/segment.rs
+++ b/src/segment.rs
@@ -7,7 +7,8 @@ use std::ops::{Deref, DerefMut};
 #[cfg(unix)]
 use std::os::unix::fs::{FileExt, OpenOptionsExt};
 #[cfg(windows)]
-use std::os::windows::fs::{FileExt};use std::path::Path;
+use std::os::windows::fs::{FileExt};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;


### PR DESCRIPTION
为segment模块添加windows支持
```rust
#[cfg(unix)]
use std::os::unix::fs::{FileExt, OpenOptionsExt};
#[cfg(windows)]
use std::os::windows::fs::{FileExt};use std::path::Path;
```